### PR TITLE
refactor event code and added timer heartbeat with sequence

### DIFF
--- a/addons/godiscord/scripts/discord_bot.gd
+++ b/addons/godiscord/scripts/discord_bot.gd
@@ -5,6 +5,7 @@ extends Node
 ## Discord bot token used for Godiscord.
 ## Create a bot at [url=https://discord.com/developers/applications]Discord Dev Portal[/url]
 @export var token: String
+@onready var heartbeat_timer: Timer = Timer.new()
 
 ## Emitted when a message is recieved.
 signal message_recieved(message: DiscordMessage)
@@ -18,86 +19,123 @@ var _websocket: WebSocketPeer
 var user: DiscordUser
 
 var intents: int = DiscordIntents.DEFAULT
+## For Gateway intents, guilds, messaging, DM
+var sequence_number: int
+## For resuming sessions and heartbeating
 
 func _ready():
-    _websocket = WebSocketPeer.new()
-    _websocket.connect_to_url("wss://gateway.discord.gg/?v=9&encoding=json")
+	_websocket = WebSocketPeer.new()
+	_websocket.connect_to_url("wss://gateway.discord.gg/?v=9&encoding=json")
+	heartbeat_timer.autostart = false
+	heartbeat_timer.one_shot = false
+	heartbeat_timer.timeout.connect(_heartbeat)
+	add_child(heartbeat_timer)
 
 func _process(_delta):
-    _websocket.poll()
-    var state = _websocket.get_ready_state()
-    if state == WebSocketPeer.STATE_OPEN:
-        while _websocket.get_available_packet_count():
-            var data = _websocket.get_packet().get_string_from_utf8()
-            var json = JSON.parse_string(data)
-            if json["op"] == 10:  # Hello
-                var heartbeat_interval = json["d"]["heartbeat_interval"] / 1000.0
-                _send_identify()
-                _start_heartbeat(heartbeat_interval)
-            elif json["op"] == 0 and json["t"] == "READY":
-                user = DiscordUser.new()
-                user.id = int(json["d"]["user"]["id"])
-                user.name = json["d"]["user"]["username"]
-                bot_ready.emit()
-            elif json["op"] == 0 and json["t"] == "MESSAGE_CREATE":
-                var message = DiscordMessage.new()
-                message.token = token
-                message.content = json["d"]["content"]
-                message.author = DiscordUser.new()
-                message.author.id = int(json["d"]["author"]["id"])
-                # For some reason global_name returns null here
-                #message.author.global_name = json["d"]["author"]["global_name"]
-                message.author.name = json["d"]["author"]["username"]
-                message.channel = DiscordChannel.new()
-                message.channel.token = token
-                message.channel.id = int(json["d"]["channel_id"])
-                message.id = int(json["d"]["id"])
-
-                message_recieved.emit(message)
-            elif json["op"] == 0 and json["t"] == "INTERACTION_CREATE":
-                var options = {}
-
-                if json["d"]["data"].has("options"):
-                    for i in json["d"]["data"]["options"]:
-                        options[i["name"]] = i["value"]
-
-                var command_request = DiscordCommandRequest.new()
-                command_request.options = options
-                command_request.token = token
-                command_request.interaction = json["d"]
-                command_request.name = json["d"]["data"]["name"]
-                command_request.caller = DiscordUser.new()
-                command_request.caller.id = json["d"]["member"]["user"]["id"]
-                command_request.caller.global_name = json["d"]["member"]["user"]["global_name"]
-                command_request.caller.name = json["d"]["member"]["user"]["username"]
-                command_used.emit(command_request)
-    elif state == WebSocketPeer.STATE_CLOSING:
-        pass
-    elif state == WebSocketPeer.STATE_CLOSED:
-        var code = _websocket.get_close_code()
-        var reason = _websocket.get_close_reason()
-        print("WebSocket closed with code: %d, reason %s. Clean: %s" % [code, reason, code != -1])
-        set_process(false)
+	_websocket.poll()
+	var state = _websocket.get_ready_state()
+	
+	if state == WebSocketPeer.STATE_OPEN:
+		while _websocket.get_available_packet_count():
+			var data = _websocket.get_packet().get_string_from_utf8()
+			var json = JSON.parse_string(data)
+			var Opcode: int = json["op"]
+			
+			if Opcode == DiscordOpcodes.DISPATCH:
+				_event_handler(json)
+				continue
+			
+			if Opcode == DiscordOpcodes.HELLO:
+				var heartbeat_interval: float = json["d"]["heartbeat_interval"] / 1000.0
+				var jitter: float = randf() # 
+				heartbeat_timer.wait_time = heartbeat_interval
+				_send_identify()
+				_start_heartbeat(heartbeat_interval * jitter)
+				
+			# TODO: add handlers for other opcodes
+		
+	elif state == WebSocketPeer.STATE_CLOSING:
+		pass
+		
+	elif state == WebSocketPeer.STATE_CLOSED:
+		var code = _websocket.get_close_code()
+		var reason = _websocket.get_close_reason()
+		print("WebSocket closed with code: %d, reason %s. Clean: %s" % [code, reason, code != -1])
+		set_process(false)
 
 func _send_identify():
-    var payload = {
-        "op": 2,
-        "d": {
-            "token": token,
-            "intents": intents,
-            "properties": {
-                "$os": OS.get_name(),
-                "$browser": "godot",
-                "$device": "godot"
-            }
-        }
-    }
-    _websocket.put_packet(JSON.stringify(payload).to_utf8_buffer())
+	var payload = {
+		"op": 2,
+		"d": {
+			"token": token,
+			"intents": intents,
+			"properties": {
+				"$os": OS.get_name(),
+				"$browser": "godot",
+				"$device": "godot"
+			}
+		}
+	}
+	_websocket.put_packet(JSON.stringify(payload).to_utf8_buffer())
+
+func _event_handler(payload: Dictionary):
+	# Reference https://discord.com/developers/docs/events/gateway-events#payload-structure
+	var event: String = payload["t"]
+	var sequence: int = payload["s"]
+	var data: Dictionary = payload["d"]
+	
+	sequence_number = sequence
+	if event == "READY":
+		user = DiscordUser.new()
+		user.id = int(data["user"]["id"])
+		user.name = data["user"]["username"]
+		bot_ready.emit()
+		
+	elif event == "MESSAGE_CREATE":
+		var message = DiscordMessage.new()
+		message.token = token
+		message.content = data["content"]
+		message.author = DiscordUser.new()
+		message.author.id = int(data["author"]["id"])
+		# For some reason global_name returns null here
+		# ^- From kruz: maybe it is an intent?  I see my user when
+		# printing the global_name, but I'm using more intents
+		message.author.global_name = data["author"]["global_name"]
+		message.author.name = data["author"]["username"]
+		message.channel = DiscordChannel.new()
+		message.channel.token = token
+		message.channel.id = int(data["channel_id"])
+		message.id = int(data["id"])
+
+		message_recieved.emit(message)
+		
+	elif event == "INTERACTION_CREATE":
+		var options = {}
+
+		if data["data"].has("options"):
+			for i in data["data"]["options"]:
+				options[i["name"]] = i["value"]
+
+		var command_request = DiscordCommandRequest.new()
+		command_request.options = options
+		command_request.token = token
+		command_request.interaction = data
+		command_request.name = data["data"]["name"]
+		command_request.caller = DiscordUser.new()
+		command_request.caller.id = data["member"]["user"]["id"]
+		command_request.caller.global_name = data["member"]["user"]["global_name"]
+		command_request.caller.name = data["member"]["user"]["username"]
+		command_used.emit(command_request)
+		
+func _heartbeat():
+	# Reference https://discord.com/developers/docs/events/gateway#sending-heartbeats
+	var data: Dictionary = {"op": 1, "d": sequence_number or null}
+	_websocket.put_packet(JSON.stringify(data).to_utf8_buffer())
 
 func _start_heartbeat(interval: float):
-    await get_tree().create_timer(interval).timeout
-    _websocket.put_packet(JSON.stringify({"op": 1, "d": null}).to_utf8_buffer())
-    _start_heartbeat(interval)
+	await get_tree().create_timer(interval).timeout
+	_heartbeat()
+	heartbeat_timer.start()
 
 ## Register a slash command to the bot.
 ## To handle the usage of commands, please read [DiscordCommandRequest].[br]
@@ -119,17 +157,17 @@ func _start_heartbeat(interval: float):
 ##     discord_bot.register_slash_command("bye", "Says goodbye", options)
 ## [/codeblock]
 func register_slash_command(command_name: String, description: String, options: Array = []):
-    var url = "https://discord.com/api/v9/applications/%s/commands" % user.id
-    var headers = [
-        "Authorization: Bot %s" % token,
-        "Content-Type: application/json"
-    ]
-    var payload = {
-        "name": command_name,
-        "description": description,
-        "options": options
-    }
-    var http_req = HTTPRequest.new()
-    DiscordRequestHandler.add_child(http_req)
-    http_req.request_completed.connect(func(_r, _c, _h, _b): http_req.queue_free())
-    http_req.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
+	var url = "https://discord.com/api/v9/applications/%s/commands" % user.id
+	var headers = [
+		"Authorization: Bot %s" % token,
+		"Content-Type: application/json"
+	]
+	var payload = {
+		"name": command_name,
+		"description": description,
+		"options": options
+	}
+	var http_req = HTTPRequest.new()
+	DiscordRequestHandler.add_child(http_req)
+	http_req.request_completed.connect(func(_r, _c, _h, _b): http_req.queue_free())
+	http_req.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))

--- a/addons/godiscord/scripts/discord_opcodes.gd
+++ b/addons/godiscord/scripts/discord_opcodes.gd
@@ -1,0 +1,41 @@
+# Gateway Opcodes 
+# Reference: https://discord.com/developers/docs/topics/opcodes-and-status-codes#gateway-gateway-opcodes
+
+class_name DiscordOpcodes
+extends Resource
+
+const DISPATCH: int = 0
+#Receive	An event was dispatched.
+
+const HEARTBEAT: int = 1
+#Send/Receive	Fired periodically by the client to keep the connection alive.
+
+const IDENTIFY: int = 2
+#Send	Starts a new session during the initial handshake.
+
+const PRESENCE_UPDATE: int = 3
+#Send	Update the client's presence.
+
+const VOICE_STATE_UPDATE: int = 4
+#Send	Used to join/leave or move between voice channels.
+
+const RESUME: int = 6
+#Send	Resume a previous session that was disconnected.
+
+const RECONNECT: int = 7
+#Receive	You should attempt to reconnect and resume immediately.
+
+const REQUEST_GUILD_MEMBERS: int = 8
+#Send	Request information about offline guild members in a large guild.
+
+const INVALID_SESSION: int = 9
+#Receive	The session has been invalidated. You should reconnect and identify/resume accordingly.
+
+const HELLO: int = 10
+#Receive	Sent immediately after connecting, contains the heartbeat_interval to use.
+
+const HEARTBEAT_ACK: int = 11
+#Receive	Sent in response to receiving a heartbeat to acknowledge that it has been received.
+
+const REQUEST_SOUNDBOARD_SOUNDS: int = 31
+#Send	Request information about soundboard sounds in a set of guilds.


### PR DESCRIPTION
I added the Opcodes to be able to handle other events that come back from discord.  I refactored the structure of the main loop to add sequencing for all of the DiscordOpcodes.DISPATCH events that are fired.  I noticed the heartbeat wasn't doing the jitter delay on startup and wasn't sending the sequence number for resumes, so I added the jitter and sequence on a actual timer so there's no need to keep recreating the timer.

![image_2024-12-27_191820382](https://github.com/user-attachments/assets/59221f22-28dd-47d5-88e0-eb474c299157)
