### PR TITLE
Fixed slash commands not registering, added mention to discord_user.gd

### DIFF
--- a/addons/godiscord/plugin.cfg
+++ b/addons/godiscord/plugin.cfg
@@ -3,5 +3,5 @@
 name="Godiscord"
 description="Use the Discord Bot API directly within Godot! Useful for integrating your Godot game with a server, for example."
 author="Shuflduf"
-version="1.0"
+version="1.0.1"
 script="godot_discord.gd"

--- a/addons/godiscord/scripts/discord_bot.gd
+++ b/addons/godiscord/scripts/discord_bot.gd
@@ -140,6 +140,7 @@ func _event_handler(payload: Dictionary):
     command_request.caller.id = data["member"]["user"]["id"]
     command_request.caller.global_name = data["member"]["user"]["global_name"]
     command_request.caller.name = data["member"]["user"]["username"]
+    command_request.caller.mention = "<@%s>" % command_request.caller.id
     command_used.emit(command_request)
     
 func _heartbeat():

--- a/addons/godiscord/scripts/discord_bot.gd
+++ b/addons/godiscord/scripts/discord_bot.gd
@@ -174,7 +174,7 @@ func _start_heartbeat(interval: float):
 func register_slash_command(command_name: String, description: String, options: Array = []):
   if guild_id.is_empty():
     push_error("guild_id is empty. If your command does not register, enable Developer Mode in Discord, copy the Server ID, and set it in the 'guild_id' field.");
-  var url = "https://discord.com/api/v9/applications/%s/guilds/%s/commands" % [user.id, guild_id] # Agregamos GUILD_ID
+  var url = "https://discord.com/api/v9/applications/%s/guilds/%s/commands" % [user.id, guild_id]
   var headers = [
     "Authorization: Bot %s" % token,
     "Content-Type: application/json"

--- a/addons/godiscord/scripts/discord_bot.gd
+++ b/addons/godiscord/scripts/discord_bot.gd
@@ -5,6 +5,12 @@ extends Node
 ## Discord bot token used for Godiscord.
 ## Create a bot at [url=https://discord.com/developers/applications]Discord Dev Portal[/url]
 @export var token: String
+## Used to register slash commands, discords requires a GUILD_ID to register commands automatically[br]
+## for now, this will do the trick[br][br]
+## Right Click on the server image and press [color=aqua][i]Copy Server ID[/i][/color] and paste it here
+@export var guild_id: String
+
+
 @onready var heartbeat_timer: Timer = Timer.new()
 
 ## Emitted when a message is recieved.
@@ -24,121 +30,127 @@ var sequence_number: int
 ## For resuming sessions and heartbeating
 
 func _ready():
-	_websocket = WebSocketPeer.new()
-	_websocket.connect_to_url("wss://gateway.discord.gg/?v=9&encoding=json")
-	heartbeat_timer.autostart = false
-	heartbeat_timer.one_shot = false
-	heartbeat_timer.timeout.connect(_heartbeat)
-	add_child(heartbeat_timer)
+  _websocket = WebSocketPeer.new()
+  _websocket.connect_to_url("wss://gateway.discord.gg/?v=9&encoding=json")
+  heartbeat_timer.autostart = false
+  heartbeat_timer.one_shot = false
+  heartbeat_timer.timeout.connect(_heartbeat)
+
+  if guild_id.is_empty():
+    push_warning("guild_id is empty, commands may not work!")
+  if guild_id.length() < 18 or not guild_id.is_valid_int(): # if discord changes their api, this will not work
+    push_warning("guild_id may not be a valid discord server id")
+
+  add_child(heartbeat_timer)
 
 func _process(_delta):
-	_websocket.poll()
-	var state = _websocket.get_ready_state()
-	
-	if state == WebSocketPeer.STATE_OPEN:
-		while _websocket.get_available_packet_count():
-			var data = _websocket.get_packet().get_string_from_utf8()
-			var json = JSON.parse_string(data)
-			var Opcode: int = json["op"]
-			
-			if Opcode == DiscordOpcodes.DISPATCH:
-				_event_handler(json)
-				continue
-			
-			if Opcode == DiscordOpcodes.HELLO:
-				var heartbeat_interval: float = json["d"]["heartbeat_interval"] / 1000.0
-				var jitter: float = randf() # 
-				heartbeat_timer.wait_time = heartbeat_interval
-				_send_identify()
-				_start_heartbeat(heartbeat_interval * jitter)
-				
-			# TODO: add handlers for other opcodes
-		
-	elif state == WebSocketPeer.STATE_CLOSING:
-		pass
-		
-	elif state == WebSocketPeer.STATE_CLOSED:
-		var code = _websocket.get_close_code()
-		var reason = _websocket.get_close_reason()
-		print("WebSocket closed with code: %d, reason %s. Clean: %s" % [code, reason, code != -1])
-		set_process(false)
+  _websocket.poll()
+  var state = _websocket.get_ready_state()
+  
+  if state == WebSocketPeer.STATE_OPEN:
+    while _websocket.get_available_packet_count():
+      var data = _websocket.get_packet().get_string_from_utf8()
+      var json = JSON.parse_string(data)
+      var Opcode: int = json["op"]
+      
+      if Opcode == DiscordOpcodes.DISPATCH:
+        _event_handler(json)
+        continue
+      
+      if Opcode == DiscordOpcodes.HELLO:
+        var heartbeat_interval: float = json["d"]["heartbeat_interval"] / 1000.0
+        var jitter: float = randf() # 
+        heartbeat_timer.wait_time = heartbeat_interval
+        _send_identify()
+        _start_heartbeat(heartbeat_interval * jitter)
+        
+      # TODO: add handlers for other opcodes
+    
+  elif state == WebSocketPeer.STATE_CLOSING:
+    pass
+    
+  elif state == WebSocketPeer.STATE_CLOSED:
+    var code = _websocket.get_close_code()
+    var reason = _websocket.get_close_reason()
+    print("WebSocket closed with code: %d, reason %s. Clean: %s" % [code, reason, code != -1])
+    set_process(false)
 
 func _send_identify():
-	var payload = {
-		"op": 2,
-		"d": {
-			"token": token,
-			"intents": intents,
-			"properties": {
-				"$os": OS.get_name(),
-				"$browser": "godot",
-				"$device": "godot"
-			}
-		}
-	}
-	_websocket.put_packet(JSON.stringify(payload).to_utf8_buffer())
+  var payload = {
+    "op": 2,
+    "d": {
+      "token": token,
+      "intents": intents,
+      "properties": {
+        "$os": OS.get_name(),
+        "$browser": "godot",
+        "$device": "godot"
+      }
+    }
+  }
+  _websocket.put_packet(JSON.stringify(payload).to_utf8_buffer())
 
 func _event_handler(payload: Dictionary):
-	# Reference https://discord.com/developers/docs/events/gateway-events#payload-structure
-	var event: String = payload["t"]
-	var sequence: int = payload["s"]
-	var data: Dictionary = payload["d"]
-	
-	sequence_number = sequence
-	if event == "READY":
-		user = DiscordUser.new()
-		user.id = int(data["user"]["id"])
-		user.name = data["user"]["username"]
-		bot_ready.emit()
-		
-	elif event == "MESSAGE_CREATE":
-		var message = DiscordMessage.new()
-		message.token = token
-		message.content = data["content"]
-		message.author = DiscordUser.new()
-		message.author.id = int(data["author"]["id"])
-		# For some reason global_name returns null here
-		# ^- From kruz: maybe it is an intent?  I see my user when
-		# printing the global_name, but I'm using more intents
-		# ^- Shuflduf: Im not sure what intents youre using, so im 
-		# safeguard this a bit
-		if data["author"]["global_name"] != null:
-			message.author.global_name = data["author"]["global_name"]
-		message.author.name = data["author"]["username"]
-		message.channel = DiscordChannel.new()
-		message.channel.token = token
-		message.channel.id = int(data["channel_id"])
-		message.id = int(data["id"])
+  # Reference https://discord.com/developers/docs/events/gateway-events#payload-structure
+  var event: String = payload["t"]
+  var sequence: int = payload["s"]
+  var data: Dictionary = payload["d"]
+  
+  sequence_number = sequence
+  if event == "READY":
+    user = DiscordUser.new()
+    user.id = int(data["user"]["id"])
+    user.name = data["user"]["username"]
+    bot_ready.emit()
+    
+  elif event == "MESSAGE_CREATE":
+    var message = DiscordMessage.new()
+    message.token = token
+    message.content = data["content"]
+    message.author = DiscordUser.new()
+    message.author.id = int(data["author"]["id"])
+    # For some reason global_name returns null here
+    # ^- From kruz: maybe it is an intent?  I see my user when
+    # printing the global_name, but I'm using more intents
+    # ^- Shuflduf: Im not sure what intents youre using, so im 
+    # safeguard this a bit
+    if data["author"]["global_name"] != null:
+      message.author.global_name = data["author"]["global_name"]
+    message.author.name = data["author"]["username"]
+    message.channel = DiscordChannel.new()
+    message.channel.token = token
+    message.channel.id = int(data["channel_id"])
+    message.id = int(data["id"])
 
-		message_recieved.emit(message)
-		
-	elif event == "INTERACTION_CREATE":
-		var options = {}
+    message_recieved.emit(message)
+    
+  elif event == "INTERACTION_CREATE":
+    var options = {}
 
-		if data["data"].has("options"):
-			for i in data["data"]["options"]:
-				options[i["name"]] = i["value"]
+    if data["data"].has("options"):
+      for i in data["data"]["options"]:
+        options[i["name"]] = i["value"]
 
-		var command_request = DiscordCommandRequest.new()
-		command_request.options = options
-		command_request.token = token
-		command_request.interaction = data
-		command_request.name = data["data"]["name"]
-		command_request.caller = DiscordUser.new()
-		command_request.caller.id = data["member"]["user"]["id"]
-		command_request.caller.global_name = data["member"]["user"]["global_name"]
-		command_request.caller.name = data["member"]["user"]["username"]
-		command_used.emit(command_request)
-		
+    var command_request = DiscordCommandRequest.new()
+    command_request.options = options
+    command_request.token = token
+    command_request.interaction = data
+    command_request.name = data["data"]["name"]
+    command_request.caller = DiscordUser.new()
+    command_request.caller.id = data["member"]["user"]["id"]
+    command_request.caller.global_name = data["member"]["user"]["global_name"]
+    command_request.caller.name = data["member"]["user"]["username"]
+    command_used.emit(command_request)
+    
 func _heartbeat():
-	# Reference https://discord.com/developers/docs/events/gateway#sending-heartbeats
-	var data: Dictionary = {"op": 1, "d": sequence_number or null}
-	_websocket.put_packet(JSON.stringify(data).to_utf8_buffer())
+  # Reference https://discord.com/developers/docs/events/gateway#sending-heartbeats
+  var data: Dictionary = {"op": 1, "d": sequence_number or null}
+  _websocket.put_packet(JSON.stringify(data).to_utf8_buffer())
 
 func _start_heartbeat(interval: float):
-	await get_tree().create_timer(interval).timeout
-	_heartbeat()
-	heartbeat_timer.start()
+  await get_tree().create_timer(interval).timeout
+  _heartbeat()
+  heartbeat_timer.start()
 
 ## Register a slash command to the bot.
 ## To handle the usage of commands, please read [DiscordCommandRequest].[br]
@@ -160,17 +172,19 @@ func _start_heartbeat(interval: float):
 ##     discord_bot.register_slash_command("bye", "Says goodbye", options)
 ## [/codeblock]
 func register_slash_command(command_name: String, description: String, options: Array = []):
-	var url = "https://discord.com/api/v9/applications/%s/commands" % user.id
-	var headers = [
-		"Authorization: Bot %s" % token,
-		"Content-Type: application/json"
-	]
-	var payload = {
-		"name": command_name,
-		"description": description,
-		"options": options
-	}
-	var http_req = HTTPRequest.new()
-	DiscordRequestHandler.add_child(http_req)
-	http_req.request_completed.connect(func(_r, _c, _h, _b): http_req.queue_free())
-	http_req.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))
+  if guild_id.is_empty():
+    push_error("guild_id is empty. If your command does not register, enable Developer Mode in Discord, copy the Server ID, and set it in the 'guild_id' field.");
+  var url = "https://discord.com/api/v9/applications/%s/guilds/%s/commands" % [user.id, guild_id] # Agregamos GUILD_ID
+  var headers = [
+    "Authorization: Bot %s" % token,
+    "Content-Type: application/json"
+  ]
+  var payload = {
+    "name": command_name,
+    "description": description,
+    "options": options
+  }
+  var http_req = HTTPRequest.new()
+  DiscordRequestHandler.add_child(http_req)
+  http_req.request_completed.connect(func(_r, _c, _h, _b): http_req.queue_free())
+  http_req.request(url, headers, HTTPClient.METHOD_POST, JSON.stringify(payload))

--- a/addons/godiscord/scripts/discord_user.gd
+++ b/addons/godiscord/scripts/discord_user.gd
@@ -4,3 +4,4 @@ extends DiscordResource
 var name: String
 var global_name: String
 var id: int
+var mention: String


### PR DESCRIPTION
the fix to the slash commands it's just a work around, it's not designed tu be automatically added and YOU need to add the server id directly into the `discord_bot.gd` for it to work and add the commands. I hope someone more clever than me can fix this. Maybe getting all the servers the bot is in and updating the slash commands??? Maybe????

Also added a `mention` field to the `discord_user.gd` so it feels closer to *discordpy*

**Discordpy**

```
@client.tree.command(name="hello", description="just says hello", guild=GUILD_ID)
async def hello(interaction:discord.Interaction):
  await interaction.response.send_message(f"Hello {interaction.user.mention}")
```

Godiscord (with mention and guild_id added)

```
func _ready() -> void:
  bot.bot_ready.connect(func():
    bot.register_slash_command("hello", "just says hello")
    bot.command_used.connect(func(command:DiscordCommandRequest):
      match command.name:
        "hello": command.reply("Hello %s" %command.caller.mention)
        pass
      pass)
    pass)
  pass

```